### PR TITLE
fix: force shell to be bash

### DIFF
--- a/alpkg
+++ b/alpkg
@@ -45,6 +45,7 @@ create-pkg-script() {
   cat <<-'_EOF_' >"$CHROOT_DIR/$PACKAGE_DIR/pkg.sh"
 		#!/usr/bin/env bash
 		set -e
+    export SHELL=bash
 		pkg=""
 		lint_pkg=false
 		edit_pkg=true


### PR DESCRIPTION
If you are using something other than bash for your host shell (zsh for example), which are not available on the build env, the shell will not execute and the right pane is empty. To prevent this, the shell need to be forced to bash.

This fixes #4